### PR TITLE
only next() once we have committed

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,9 @@ module.exports = function (handler, config) {
   var pressure = pressureStream(function (change, next) {
     var saveSeq = seq(change.seq)
     handler(change, function (err, data) {
-      saveSeq()
-      next(err, data)
+      saveSeq(function (err2) {
+        next(err2 || err, data)
+      })
     })
   }, {
     high: config.concurrency || 4,


### PR DESCRIPTION
This forwards the error out to `pressure` as an error event, where it can be caught by consuming packages (or immediately crash if no listeners are present.)